### PR TITLE
Bump publish-mason-brick to 1.0.3

### DIFF
--- a/.github/workflows/publish_to_brickyard.yaml
+++ b/.github/workflows/publish_to_brickyard.yaml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: publish_codepad
-        uses: abitofevrything/publish-mason-brick@1.0.2
+        uses: abitofevrything/publish-mason-brick@1.0.3
         with:
           path: codepad
           email: ${{ secrets.BRICKHUB_EMAIL }}


### PR DESCRIPTION
Bump the publish-mason-brick action to 1.0.3, which fixes the deprecation warnings.